### PR TITLE
Revert "drm/rcar: stop using 'imply' for dependencies"

### DIFF
--- a/drivers/gpu/drm/rcar-du/Kconfig
+++ b/drivers/gpu/drm/rcar-du/Kconfig
@@ -4,6 +4,8 @@ config DRM_RCAR_DU
 	depends on DRM && OF
 	depends on ARM || ARM64
 	depends on ARCH_RENESAS || COMPILE_TEST
+	imply DRM_RCAR_CMM
+	imply DRM_RCAR_LVDS
 	select DRM_KMS_HELPER
 	select DRM_KMS_CMA_HELPER
 	select DRM_GEM_CMA_HELPER
@@ -12,16 +14,12 @@ config DRM_RCAR_DU
 	  Choose this option if you have an R-Car chipset.
 	  If M is selected the module will be called rcar-du-drm.
 
-config DRM_RCAR_USE_CMM
-	bool "R-Car DU Color Management Module (CMM) Support"
+config DRM_RCAR_CMM
+	tristate "R-Car DU Color Management Module (CMM) Support"
+	depends on DRM && OF
 	depends on DRM_RCAR_DU
-	default DRM_RCAR_DU
 	help
 	  Enable support for R-Car Color Management Module (CMM).
-
-config DRM_RCAR_CMM
-	def_tristate DRM_RCAR_DU
-	depends on DRM_RCAR_USE_CMM
 
 config DRM_RCAR_DW_HDMI
 	tristate "R-Car Gen3 and RZ/G2 DU HDMI Encoder Support"
@@ -30,20 +28,15 @@ config DRM_RCAR_DW_HDMI
 	help
 	  Enable support for R-Car Gen3 or RZ/G2 internal HDMI encoder.
 
-config DRM_RCAR_USE_LVDS
-	bool "R-Car DU LVDS Encoder Support"
-	depends on DRM_BRIDGE && OF
-	default DRM_RCAR_DU
-	help
-	  Enable support for the R-Car Display Unit embedded LVDS encoders.
-
 config DRM_RCAR_LVDS
-	def_tristate DRM_RCAR_DU
-	depends on DRM_RCAR_USE_LVDS
+	tristate "R-Car DU LVDS Encoder Support"
+	depends on DRM && DRM_BRIDGE && OF
 	select DRM_KMS_HELPER
 	select DRM_PANEL
 	select OF_FLATTREE
 	select OF_OVERLAY
+	help
+	  Enable support for the R-Car Display Unit embedded LVDS encoders.
 
 config DRM_RCAR_VSP
 	bool "R-Car DU VSP Compositor Support" if ARM


### PR DESCRIPTION
This reverts commit feead97d303f72e189137f2e5644a5cb484b8b62 to resolve the following issue:

The probe for drm bridge defers continuously with this commit causing imx8m plus to stuck at boot. The following errors are logged:

[drm:drm_bridge_attach] *ERROR* failed to attach bridge /soc@0/bus@32c00000/mipi_dsi@32e60000 to encoder DSI-40: -517
imx_sec_dsim_drv 32e60000.mipi_dsi: Failed to attach bridge: 32e60000.mipi_dsi
imx_sec_dsim_drv 32e60000.mipi_dsi: failed to bind sec dsim bridge: -517

JIRA: SB-21039