### PR TITLE
Revert "revert "drm/rcar: stop using 'imply' for dependencies"" 

### DIFF
--- a/drivers/gpu/drm/bridge/adv7511/Kconfig
+++ b/drivers/gpu/drm/bridge/adv7511/Kconfig
@@ -5,6 +5,7 @@ config DRM_I2C_ADV7511
 	select DRM_KMS_HELPER
 	select REGMAP_I2C
 	select DRM_MIPI_DSI
+	select OF_OVERLAY
 	help
 	  Support for the Analog Devices ADV7511(W)/13/33/35 HDMI encoders.
 

--- a/drivers/gpu/drm/rcar-du/Kconfig
+++ b/drivers/gpu/drm/rcar-du/Kconfig
@@ -4,8 +4,6 @@ config DRM_RCAR_DU
 	depends on DRM && OF
 	depends on ARM || ARM64
 	depends on ARCH_RENESAS || COMPILE_TEST
-	imply DRM_RCAR_CMM
-	imply DRM_RCAR_LVDS
 	select DRM_KMS_HELPER
 	select DRM_KMS_CMA_HELPER
 	select DRM_GEM_CMA_HELPER
@@ -14,12 +12,16 @@ config DRM_RCAR_DU
 	  Choose this option if you have an R-Car chipset.
 	  If M is selected the module will be called rcar-du-drm.
 
-config DRM_RCAR_CMM
-	tristate "R-Car DU Color Management Module (CMM) Support"
-	depends on DRM && OF
+config DRM_RCAR_USE_CMM
+	bool "R-Car DU Color Management Module (CMM) Support"
 	depends on DRM_RCAR_DU
+	default DRM_RCAR_DU
 	help
 	  Enable support for R-Car Color Management Module (CMM).
+
+config DRM_RCAR_CMM
+	def_tristate DRM_RCAR_DU
+	depends on DRM_RCAR_USE_CMM
 
 config DRM_RCAR_DW_HDMI
 	tristate "R-Car Gen3 and RZ/G2 DU HDMI Encoder Support"
@@ -28,15 +30,20 @@ config DRM_RCAR_DW_HDMI
 	help
 	  Enable support for R-Car Gen3 or RZ/G2 internal HDMI encoder.
 
+config DRM_RCAR_USE_LVDS
+	bool "R-Car DU LVDS Encoder Support"
+	depends on DRM_BRIDGE && OF
+	default DRM_RCAR_DU
+	help
+	  Enable support for the R-Car Display Unit embedded LVDS encoders.
+
 config DRM_RCAR_LVDS
-	tristate "R-Car DU LVDS Encoder Support"
-	depends on DRM && DRM_BRIDGE && OF
+	def_tristate DRM_RCAR_DU
+	depends on DRM_RCAR_USE_LVDS
 	select DRM_KMS_HELPER
 	select DRM_PANEL
 	select OF_FLATTREE
 	select OF_OVERLAY
-	help
-	  Enable support for the R-Car Display Unit embedded LVDS encoders.
 
 config DRM_RCAR_VSP
 	bool "R-Car DU VSP Compositor Support" if ARM


### PR DESCRIPTION
ADV7535 is a display interface bridge chip (drm bridge) which is being used to convert MIPI DSI signals to HDMI. There are two endpoints defined in the dts, dsim_to_adv7535 for the node mipi_dsi and adv7535_from_dsim for the node i2c2. The driver for adv7535 makes use of CONFIG_OF_DYNAMIC to dynamically disable/detach the remote endpoint in devicetree if the physical i2c client fails to probe. This is done because usually the remote endpoint of this device is a DRM encoder and If a DRM encoder fails to bind, the DRM master device will also fail to bind which is undesirable because DRM master device should be available to bind for any other available devices[1][2]. When the support for CONFIG_OF_DYNAMIC was added in the driver, its dependency was not added in the corresponding Kconfig. But at that time, it was not failing at runtime because the CONFIG_DRM_RCAR_LVDS was enabled in the defconfig which was enabling CONFIG_OF_OVERLAY which selects CONFIG_OF_DYNAMIC. Now, when the drm/rcar patch made changes to the kconfig and introduced a new dependency CONFIG_DRM_RCAR_USE_LVDS for CONFIG_DRM_RCAR_LVDS, the CONFIG_OF_OVERLAY got disabled since it was not being selected anywhere else, hence triggering the issue.

The whole display pipeline is disabled in the upstream stable kernel (the related device tree nodes are only available in the vendor tree) and given that issue we were facing is independent of the rcar-du patch, so there's no need to send any patch upstream.

So the root cause of the drm_bridge probe being deferred continuously is that the CONFIG_OF_DYNAMIC got disabled. We can create a config fragment to enable CONFIG_OF_DYNAMIC but it depends on CONFIG_OF_UNITTEST which we would want to keep disabled. So the right way to enable CONFIG_OF_DYNAMIC is to enable CONFIG_OF_OVERLAY.

After the above investigation, the obvious thing to do is to add a reverse dependency on CONFIG_OF_OVERLAY for the adv7535 driver and in fact this is exactly what the vendor has done in the later versions of their kernel tree[3].

References:

[1] https://github.com/MentorEmbedded/linux-flex-imx/commit/e4e4eb702f3de900643577bb9b0913472337282f 
[2] https://github.com/MentorEmbedded/linux-flex-imx/commit/a6c1a523771778c5ece0242d04d4b2fd7fcb7a0f 
[3] https://github.com/nxp-imx/linux-imx/commit/eaa7edee5b28fb1665dbfbcf51d56bf4431f98fd